### PR TITLE
MICROAPP-12740 Enable whitespaces in vendor field in metadata.json

### DIFF
--- a/bundlegen/src/main/java/com/citrix/microapps/bundlegen/bundles/BundlesLoader.java
+++ b/bundlegen/src/main/java/com/citrix/microapps/bundlegen/bundles/BundlesLoader.java
@@ -71,6 +71,9 @@ public class BundlesLoader {
     private static final Pattern VERSION_PATTERN =
             Pattern.compile("[0-9]+(?:\\.[0-9]+)*(\\.[0-9a-f]{40})?(-SNAPSHOT)?");
 
+    // e.g. `vendor: "Brick_Bridge_Consulting"`
+    private static final String WORD_SEPARATOR = "_";
+
     private static final String TOKEN_PARAMETER_NAME = "token";
     private static final String BEARER_PARAMETER_NAME = "bearer";
 
@@ -276,7 +279,8 @@ public class BundlesLoader {
             validateDeprecatedDate(metadata.getDeprecatedDate()).ifPresent(issues::add);
         }
         validateSync(bundle::getType, "type", metadata.getType()).ifPresent(issues::add);
-        validateSync(bundle::getVendor, "vendor", metadata.getVendor()).ifPresent(issues::add);
+        validateSync(bundle::getVendor, "vendor", replaceWhitespacesWithUnderscores(metadata.getVendor()))
+                .ifPresent(issues::add);
 
         validateLanguages(bundle, metadata.getI18nLanguages()).ifPresent(issues::add);
 
@@ -499,6 +503,10 @@ public class BundlesLoader {
         }
 
         return Optional.empty();
+    }
+
+    private static String replaceWhitespacesWithUnderscores(String text) {
+        return text.replaceAll(" ", WORD_SEPARATOR);
     }
 
     private static Optional<ValidationException> validationIssue(String message) {

--- a/bundlegen/src/main/java/com/citrix/microapps/bundlegen/bundles/BundlesLoader.java
+++ b/bundlegen/src/main/java/com/citrix/microapps/bundlegen/bundles/BundlesLoader.java
@@ -506,7 +506,7 @@ public class BundlesLoader {
     }
 
     private static String replaceWhitespacesWithUnderscores(String text) {
-        return text.replaceAll(" ", WORD_SEPARATOR);
+        return text != null && !text.isEmpty() ? text.replaceAll("\\s", WORD_SEPARATOR) : text;
     }
 
     private static Optional<ValidationException> validationIssue(String message) {

--- a/bundlegen/src/test/java/com/citrix/microapps/bundlegen/bundles/BundlesLoaderTest.java
+++ b/bundlegen/src/test/java/com/citrix/microapps/bundlegen/bundles/BundlesLoaderTest.java
@@ -442,7 +442,7 @@ class BundlesLoaderTest {
                                         "(\\.[0-9a-f]{40})?(-SNAPSHOT)?`",
                                 "Invalid UTC timestamp format: field `deprecatedDate`, value `bad 2019-12-18T11:36:00`",
                                 "Values mismatch: field `type`, filesystem `DIP` != metadata `HTTP`",
-                                "Values mismatch: field `vendor`, filesystem `vendor` != metadata `bad vendor`",
+                                "Values mismatch: field `vendor`, filesystem `vendor` != metadata `bad_vendor`",
                                 "Values mismatch: field `i18nLanguages`, filesystem `[]` != metadata `[bad]`",
                                 "Invalid value: field `type`, value `HTTP`, expecting `DIP`",
                                 "Invalid value: field `id`, value `bad id`, pattern `[a-zA-Z0-9]+(?:\\.[a-zA-Z0-9]+)*`",
@@ -502,13 +502,16 @@ class BundlesLoaderTest {
         return Stream.of(
                 Arguments.of(
                         new FsHttpBundle(
-                                Paths.get("http", "vendor", "bad 00b31529-bc3f-4dab-84c9-b0a539d51d73"),
+                                Paths.get(
+                                        "http",
+                                        "Vendor_Name_With_Whitespaces",
+                                        "bad 00b31529-bc3f-4dab-84c9-b0a539d51d73"),
                                 toPaths()),
                         defaultHttpMetadata
                                 .toBuilder()
                                 .trackingUuid(UUID.fromString("332d82b2-12cb-480d-8edb-9b9bca59a8c9"))
                                 .type(Type.DIP)
-                                .vendor("bad vendor")
+                                .vendor("Vendor Name With Whitespaces")
                                 .title("bad title")
                                 .description("bad description")
                                 .masVersion("bad 1.0.0")
@@ -522,7 +525,6 @@ class BundlesLoaderTest {
                                 "Invalid value: field `masVersion`, value `bad 1.0.0`, pattern `[0-9]+(?:\\.[0-9]+)*" +
                                         "(\\.[0-9a-f]{40})?(-SNAPSHOT)?`",
                                 "Values mismatch: field `type`, filesystem `HTTP` != metadata `DIP`",
-                                "Values mismatch: field `vendor`, filesystem `vendor` != metadata `bad vendor`",
                                 "Values mismatch: field `i18nLanguages`, filesystem `[]` != metadata `[bad]`",
                                 "Invalid value: field `type`, value `DIP`, expecting `HTTP`",
                                 "Values mismatch: field `id`, filesystem `bad 00b31529-bc3f-4dab-84c9-b0a539d51d73` " +


### PR DESCRIPTION
*  Update vendor name field validation.  Enable whitespaces in vendor name in metadata.json 
*  Updated the bundle metadata handling that uses vendor name in MA server - branch feature/MICROAPP-12740
