### PR TITLE
Prevent failure during bundles validation due to metadata parsing issues

### DIFF
--- a/bundlegen/src/main/java/com/citrix/microapps/bundlegen/bundles/Bundle.java
+++ b/bundlegen/src/main/java/com/citrix/microapps/bundlegen/bundles/Bundle.java
@@ -29,7 +29,8 @@ public class Bundle {
 
     public Metadata getMetadata() {
         return metadata
-                .orElseThrow(() -> new UnsupportedOperationException("No metadata, validations should prevent this"));
+                .orElseThrow(() -> new UnsupportedOperationException(String.format("Bundle: '%s' contains no metadata, " +
+                        "validations should have prevented this", this)));
     }
 
     public List<BundleIssue> getIssues() {

--- a/bundlegen/src/main/java/com/citrix/microapps/bundlegen/bundles/BundlesProcessor.java
+++ b/bundlegen/src/main/java/com/citrix/microapps/bundlegen/bundles/BundlesProcessor.java
@@ -99,9 +99,7 @@ public class BundlesProcessor {
     }
 
     private boolean isWarningIssueOnlyForValidatedBundle(Bundle bundle, BundleIssue issue) {
-        return (issue.getSeverity() == WARNING
-                && Instant.from(CREATION_DATETIME_FORMATTER.parse(bundle.getMetadata().getCreated()))
-                .isAfter(bestPractisesValidationLimit))
+        return (issue.getSeverity() == WARNING && createdAfterBestPractisesValidationLimit(bundle))
                 || issue.getSeverity() == ERROR;
     }
 
@@ -156,6 +154,15 @@ public class BundlesProcessor {
             METADATA_WRITER.writeValue(bundlesJson.toFile(), bundles);
         } catch (IOException e) {
             throw new UncheckedIOException("Writing bundles JSON failed", e);
+        }
+    }
+
+    private boolean createdAfterBestPractisesValidationLimit(Bundle bundle) {
+        try {
+            return Instant.from(CREATION_DATETIME_FORMATTER.parse(bundle.getMetadata().getCreated()))
+                    .isAfter(bestPractisesValidationLimit);
+        } catch (UnsupportedOperationException e) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
If parsing of bundle's metadata fails, the bundle will be created without metadata. Subsequent filtering of validation issues will throw an exception, and there will be no information in the log regarding which bundle's metadata caused the problem.