### PR TITLE
MICROAPP-12642 - Workday (Actions) deprecation

### DIFF
--- a/bundles/dip/Citrix/com.sapho.services.workday.pto.WorkdayRequestPtoService/0.1.0/metadata.json
+++ b/bundles/dip/Citrix/com.sapho.services.workday.pto.WorkdayRequestPtoService/0.1.0/metadata.json
@@ -8,8 +8,10 @@
   "description" : "Use integration in conjunction with Workday (Notifications) integration to enable Service Actions for requesting PTO",
   "iconUrl" : "https://ctx-ws-cdn.cloud.com/assets/microapps/exported/Workday.53a6fa429a68457228ca68adf0c387e6.svg",
   "masVersion" : "1.42.0-SNAPSHOT",
-  "categories" : [ "WEB_SERVICES" ],
+  "categories" : [ "LEGACY" ],
   "created" : "2020-11-11T17:26:33",
+  "deprecatedDate": "2021-04-21T00:00:00Z",
+  "eolDateWithSupport": "2021-04-21T00:00:00Z",
   "supportsOAuthForActions" : false,
   "i18nLanguages" : [ "de", "en", "es", "fr", "it", "ja", "nl", "pt-BR", "zh-CN" ],
   "apps" : [ {


### PR DESCRIPTION
Workday (Actions) marked as deprecated with deprecation and eol date set for 04/21/2021 as we no longer want this integration visible in catalog.