### PR TITLE
MICROAPP-15578 Remove default values for template variables for Jira

### DIFF
--- a/bundles/http/Citrix/Jira-scripting/file.sapp
+++ b/bundles/http/Citrix/Jira-scripting/file.sapp
@@ -26525,8 +26525,7 @@
           },
           "value" : {
             "type" : "PARENT_DATA",
-            "parentColumn" : "actor_group_name",
-            "defaultValue" : "NULL"
+            "parentColumn" : "actor_group_name"
           }
         } ],
         "fullSynchronization" : {
@@ -27072,8 +27071,7 @@
           },
           "value" : {
             "type" : "PARENT_DATA",
-            "parentColumn" : "name",
-            "defaultValue" : "jira-software-users"
+            "parentColumn" : "name"
           }
         } ],
         "fullSynchronization" : {

--- a/bundles/http/Citrix/Jira/file.sapp
+++ b/bundles/http/Citrix/Jira/file.sapp
@@ -19949,8 +19949,7 @@
           },
           "value" : {
             "type" : "PARENT_DATA",
-            "parentColumn" : "name",
-            "defaultValue" : "NULL"
+            "parentColumn" : "name"
           }
         } ],
         "fullSynchronization" : {
@@ -20115,8 +20114,7 @@
           },
           "value" : {
             "type" : "PARENT_DATA",
-            "parentColumn" : "actor_group_name",
-            "defaultValue" : "NULL"
+            "parentColumn" : "actor_group_name"
           }
         } ],
         "fullSynchronization" : {


### PR DESCRIPTION
Jira bundles define default values for template variables in "group members" and "project role group members" child endpoints. These default values are used if the Jira group name is not available in the parent's table record. For example, if the response from Jira for the "project role members" endpoint does not contain the "actorGroup/name" field, this value will be 'null' in the project_role_members table, and the "project role group members" child call will use the default value of NULL. The request to '<base_url>/rest/api/2/group/member?groupname=NULL&maxResults=100&startAt=0' will return status code 404 anyway - there is no "NULL" group defined in Jira.
I think for these requests, when the integration tries to acquire group members, trying to come up with a default group name is not the best approach. If the group name is not available from the parent endpoint, the child call should be skipped altogether. This is how MAS behaves currently when the template variable value is missing in the parent table and does not have the default value.